### PR TITLE
Flux: Use main branch.

### DIFF
--- a/flux/flux-system/gotk-sync.yaml
+++ b/flux/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m
   ref:
-    branch: flux
+    branch: main
   secretRef:
     name: flux-system
   url: ssh://git@github.com/attilaolah/homelab


### PR DESCRIPTION
The main branch has branch protection so Flux will only be able to pull changes, needs configuration to push to another branch.

In the long term it'd be a better idea to reconcile from OCI artifacts anyway.