### PR TITLE
Fix Renovate config, once again

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
+  "enabledManagers": [
+    "custom.regex",
+    "nix"
+  ],
   "nix": {
     "enabled": true
   },
@@ -10,9 +14,12 @@
       "description": "Cluster dependencies",
       "fileMatch": "cluster/versions\\.nix$",
       "matchStrings": [
-        "(?<depName>[^\\s\\.]+)\\.(?<datasource>\\S+) = \\[\"(?<registryUrl>.+?)\" \"(?<currentValue>.+?)\"[^\\n]*"
+        "(?<depName>[^\\s\\.]+)\\.(?<datasource>helm) = \\[\"(?<registryUrl>https://.+?)\" \"(?<currentValue>.+?)\"[^\\n]*",
+        "(?<helmChart>[^\\s\\.]+)\\.helm = \\[\"(?<scheme>oci)://(?<helmRepo>.+?)\" \"(?<currentValue>.+?)\"[^\\n]*",
+        "[^\\s\\.]+\\.(?<datasource>github-releases) = \\[\"(?<registryUrl>https://github.com)/(?<depName>[^\"]+)\" \"(?<currentValue>.+?)\"[^\\n]*",
       ],
-      "datasourceTemplate": "{{#if (equals (lookup (split registryUrl '://') 0) 'oci')}}docker{{else}}{{{datasource}}}{{/if}}",
+      "depNameTemplate": "{{#if (equals scheme 'oci')}}{{{helmRepo}}}/{{{helmChart}}}{{else}}{{{depName}}}{{/if}}",
+      "datasourceTemplate": "{{#if (equals scheme 'oci')}}docker{{else}}{{{datasource}}}{{/if}}",
       "extractVersionTemplate": "^v?(?<version>.*)$",
       "versioningTemplate": "helm"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,7 @@
       "matchStrings": [
         "(?<depName>[^\\s\\.]+)\\.(?<datasource>helm) = \\[\"(?<registryUrl>https://.+?)\" \"(?<currentValue>.+?)\"[^\\n]*",
         "(?<helmChart>[^\\s\\.]+)\\.helm = \\[\"(?<scheme>oci)://(?<helmRepo>.+?)\" \"(?<currentValue>.+?)\"[^\\n]*",
+        "[^\\s\\.]+\\.(?<datasource>docker) = \\[\"(?<depName>.+?)\" \"(?<currentValue>.+?)\"[^\\n]*",
         "[^\\s\\.]+\\.(?<datasource>github-releases) = \\[\"(?<registryUrl>https://github.com)/(?<depName>[^\"]+)\" \"(?<currentValue>.+?)\"[^\\n]*",
       ],
       "depNameTemplate": "{{#if (equals scheme 'oci')}}{{{helmRepo}}}/{{{helmChart}}}{{else}}{{{depName}}}{{/if}}",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,8 +16,7 @@
       "matchStrings": [
         "(?<depName>[^\\s\\.]+)\\.(?<datasource>helm) = \\[\"(?<registryUrl>https://.+?)\" \"(?<currentValue>.+?)\"[^\\n]*",
         "(?<helmChart>[^\\s\\.]+)\\.helm = \\[\"(?<scheme>oci)://(?<helmRepo>.+?)\" \"(?<currentValue>.+?)\"[^\\n]*",
-        "[^\\s\\.]+\\.(?<datasource>docker) = \\[\"(?<depName>.+?)\" \"(?<currentValue>.+?)\"[^\\n]*",
-        "[^\\s\\.]+\\.(?<datasource>github-releases) = \\[\"(?<registryUrl>https://github.com)/(?<depName>[^\"]+)\" \"(?<currentValue>.+?)\"[^\\n]*",
+        "[^\\s\\.]+\\.(?<datasource>docker|github-releases) = \\[\"(?<depName>[^\"]+?)\" \"(?<currentValue>.+?)\"[^\\n]*"
       ],
       "depNameTemplate": "{{#if (equals scheme 'oci')}}{{{helmRepo}}}/{{{helmChart}}}{{else}}{{{depName}}}{{/if}}",
       "datasourceTemplate": "{{#if (equals scheme 'oci')}}docker{{else}}{{{datasource}}}{{/if}}",

--- a/cluster/versions.nix
+++ b/cluster/versions.nix
@@ -9,7 +9,7 @@ in {
   descheduler.helm = ["https://kubernetes-sigs.github.io/descheduler" "0.32.1"];
   external-secrets.helm = ["https://charts.external-secrets.io" "0.14.0"];
   flux-operator.helm = ["oci://ghcr.io/controlplaneio-fluxcd/charts" "0.10.0"];
-  flux.github-releases = ["https://github.com/fluxcd/flux2" "2.4.0"];
+  flux.github-releases = ["fluxcd/flux2" "2.4.0"];
   goldilocks.helm = ["https://charts.fairwinds.com/stable" "9.0.1"];
   grafana.helm = ["https://grafana.github.io/helm-charts" "8.9.0"];
   homepage.docker = ["ghcr.io/gethomepage/homepage" "0.9.13" vp];
@@ -18,8 +18,8 @@ in {
   inadyn.helm = ["https://charts.philippwaller.com" "1.1.0"];
   ingress-nginx.helm = ["https://kubernetes.github.io/ingress-nginx" "4.12.0"];
   kubelet-csr-approver.helm = ["https://postfinance.github.io/kubelet-csr-approver" "1.2.5"];
-  kubernetes.github-releases = ["https://github.com/kubernetes/kubernetes" "1.32.1" vp];
-  local-path-provisioner.github-releases = ["https://github.com/rancher/local-path-provisioner" "0.0.30" vp];
+  kubernetes.github-releases = ["kubernetes/kubernetes" "1.32.1" vp];
+  local-path-provisioner.github-releases = ["rancher/local-path-provisioner" "0.0.30" vp];
   loki.helm = ["https://grafana.github.io/helm-charts" "6.25.1"];
   metrics-server.helm = ["https://kubernetes-sigs.github.io/metrics-server" "3.12.2"];
   minecraft-bedrock.helm = ["https://itzg.github.io/minecraft-server-charts" "2.8.2"];
@@ -27,7 +27,7 @@ in {
   rancher.helm = ["https://releases.rancher.com/server-charts/latest" "2.10.2"];
   reloader.helm = ["oci://ghcr.io/stakater/charts" "1.2.0"];
   spegel.helm = ["oci://ghcr.io/spegel-org/helm-charts" "0.0.27" vp];
-  talos.github-releases = ["https://github.com/siderolabs/talos" "1.9.2" vp];
+  talos.github-releases = ["siderolabs/talos" "1.9.2" vp];
   vector.helm = ["https://helm.vector.dev" "0.40.0"];
   vpa.helm = ["https://charts.fairwinds.com/stable" "4.7.1"];
   zfs-localpv.helm = ["https://openebs.github.io/zfs-localpv" "2.6.2"];

--- a/cluster/versions.nix
+++ b/cluster/versions.nix
@@ -12,9 +12,9 @@ in {
   flux.github-releases = ["https://github.com/fluxcd/flux2" "2.4.0"];
   goldilocks.helm = ["https://charts.fairwinds.com/stable" "9.0.1"];
   grafana.helm = ["https://grafana.github.io/helm-charts" "8.9.0"];
-  homepage.github-releases = ["https://github.com/gethomepage/homepage" "0.9.13" vp];
+  homepage.docker = ["ghcr.io/gethomepage/homepage" "0.9.13" vp];
   homepage.helm = ["https://jameswynn.github.io/helm-charts" "2.0.1"];
-  inadyn.github-releases = ["https://github.com/troglobit/inadyn" "2.12.0" vp];
+  inadyn.docker = ["troglobit/inadyn" "2.12.0" vp];
   inadyn.helm = ["https://charts.philippwaller.com" "1.1.0"];
   ingress-nginx.helm = ["https://kubernetes.github.io/ingress-nginx" "4.12.0"];
   kubelet-csr-approver.helm = ["https://postfinance.github.io/kubelet-csr-approver" "1.2.5"];

--- a/manifests/default/homepage/app/values.yaml.nix
+++ b/manifests/default/homepage/app/values.yaml.nix
@@ -96,5 +96,5 @@ in {
   #   key = "grafana-password";
   # };
 
-  image.tag = v.homepage.github-releases;
+  image.tag = v.homepage.docker;
 }

--- a/manifests/default/inadyn/app/external-secret.yaml.nix
+++ b/manifests/default/inadyn/app/external-secret.yaml.nix
@@ -8,7 +8,7 @@
 in
   k.external-secret ./. {
     data."values.yaml" = yaml.format {
-      image.tag = v.inadyn.github-releases;
+      image.tag = v.inadyn.docker;
       inadynConfig = ''
         period = 480
 


### PR DESCRIPTION
- Fix GitHub releases not setting the depName to the full owner/repo.
- Fix OCI registries not setting the depName to ghrc.io/helm/repo/chart.