### PR TITLE
Install Keycloak

### DIFF
--- a/cluster/default.nix
+++ b/cluster/default.nix
@@ -7,10 +7,11 @@
 in rec {
   name = "locker";
   domain = "dorn.haus";
+  owner = "attilaolah";
   email = "${name}@${domain}";
 
   github = {
-    owner = "attilaolah";
+    inherit owner;
     repository = "homelab";
     registry = "ghcr.io";
   };

--- a/cluster/network.nix
+++ b/cluster/network.nix
@@ -10,7 +10,8 @@ in {
     # This strict range is used only when validating whether an IP belongs to a node.
     cidr4Strict = cidr net4 16;
 
-    net6 = "fd10:8::";
+    # ULA set by the modem:
+    net6 = "fdaa:bbcc:ddee::";
     net6Len = 64;
     cidr6 = cidr net6 net6Len;
   };

--- a/cluster/versions.nix
+++ b/cluster/versions.nix
@@ -18,6 +18,7 @@ in {
   inadyn.docker = ["troglobit/inadyn" "2.12.0" vp];
   inadyn.helm = ["https://charts.philippwaller.com" "1.1.0"];
   ingress-nginx.helm = ["https://kubernetes.github.io/ingress-nginx" "4.12.0"];
+  keycloak.helm = ["oci://registry-1.docker.io/bitnamicharts" "24.4.9"];
   kube-prometheus-stack.helm = ["https://prometheus-community.github.io/helm-charts" "69.2.0"];
   kubelet-csr-approver.helm = ["https://postfinance.github.io/kubelet-csr-approver" "1.2.5"];
   kubernetes.github-releases = ["kubernetes/kubernetes" "1.32.1" vp];
@@ -38,6 +39,7 @@ in {
   Certificate.cert-manager.io = "v1";
   CiliumL2AnnouncementPolicy.cilium.io = "v2alpha1";
   CiliumLoadBalancerIPPool.cilium.io = "v2alpha1";
+  Cluster.postgresql.cnpg.io = "v1";
   ClusterIssuer.cert-manager.io = "v1";
   ClusterSecretStore.external-secrets.io = "v1beta1";
   ConfigMap = "v1";

--- a/lib/kubernetes.nix
+++ b/lib/kubernetes.nix
@@ -101,46 +101,47 @@ in {
     in
       replaceStrings ["--"] ["-"] cleanup;
   in {
-    inherit repository-name;
+    dep = dir: let
+      name = baseNameOf dir;
+      ksname = parentDirName dir;
+    in {
+      inherit (flux) namespace;
+      name =
+        if name == "app"
+        then ksname
+        else "${ksname}-${name}";
+    };
 
     kustomization = dir: overrides: let
       name = baseNameOf dir;
       namespace = parentDirName dir;
-      hasConfig = ((readDir dir).config or null) == "directory";
-      manifestPath = dir: "./${namespace}/${name}/${dir}";
-      template = ksname: spec:
+      template = subdir:
         recursiveUpdate (api "Kustomization.kustomize.toolkit.fluxcd.io" {
           metadata = {
             inherit (flux) namespace;
-            name = ksname;
+            name =
+              if subdir == "app"
+              then name
+              else "${name}-${subdir}";
           };
-          spec =
-            recursiveUpdate {
-              targetNamespace = namespace;
-              commonMetadata.labels."app.kubernetes.io/name" = name;
-              prune = true;
-              sourceRef = {
-                kind = "OCIRepository";
-                name = flux.namespace;
-              };
-              wait = true;
-              interval = "30m";
-              retryInterval = "1m";
-              timeout = "5m";
-            }
-            spec;
+          spec = {
+            path = "./${namespace}/${name}/${subdir}";
+            targetNamespace = namespace;
+            commonMetadata.labels."app.kubernetes.io/name" = name;
+            prune = true;
+            sourceRef = {
+              kind = "OCIRepository";
+              name = flux.namespace;
+            };
+            wait = true;
+            interval = "30m";
+            retryInterval = "1m";
+            timeout = "5m";
+          };
         })
-        overrides;
-
-      app = template name {path = manifestPath "app";};
-      config = template "${name}-config" {
-        path = manifestPath "config";
-        dependsOn = [app.metadata];
-      };
+        (overrides.${subdir} or {});
     in
-      if hasConfig
-      then [app config]
-      else app;
+      map template (attrNames (filterAttrs (_: type: type == "directory") (readDir dir)));
 
     git-repository = params:
       attrValues (mapAttrs (name: spec:

--- a/lib/kubernetes.nix
+++ b/lib/kubernetes.nix
@@ -100,16 +100,19 @@ in {
       cleanup = replaceStrings ["/" "." "_"] ["-" "-" "-"] noprefix;
     in
       replaceStrings ["--"] ["-"] cleanup;
-  in {
-    dep = dir: let
+    ksname = dir: let
       name = baseNameOf dir;
-      ksname = parentDirName dir;
-    in {
+      appname = parentDirName dir;
+    in
+      if name == "app"
+      then appname
+      else "${appname}-${name}";
+  in {
+    inherit ksname;
+
+    dep = dir: {
       inherit (flux) namespace;
-      name =
-        if name == "app"
-        then ksname
-        else "${ksname}-${name}";
+      name = ksname dir;
     };
 
     kustomization = dir: overrides: let

--- a/manifests/cert-manager/cert-manager/app/values.yaml.nix
+++ b/manifests/cert-manager/cert-manager/app/values.yaml.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  self,
+  cluster,
   ...
 }: {
   crds.enabled = true;
@@ -14,7 +14,7 @@
 
   dns01RecursiveNameservers =
     lib.strings.concatStringsSep ","
-    (map (ip: "https://${ip}:443/dns-query") self.lib.cluster.network.uplink.dns4.cloudflare);
+    (map (ip: "https://${ip}:443/dns-query") cluster.network.uplink.dns4.cloudflare);
   dns01RecursiveNameserversOnly = true;
 
   prometheus = {

--- a/manifests/cert-manager/cert-manager/config/cluster-issuer.yaml.nix
+++ b/manifests/cert-manager/cert-manager/config/cluster-issuer.yaml.nix
@@ -1,11 +1,9 @@
 {
-  self,
+  cluster,
   k,
   ...
 }:
 k.api "ClusterIssuer.cert-manager.io" (let
-  inherit (self.lib) cluster;
-
   prod = true;
   suffix =
     if prod

--- a/manifests/cert-manager/cert-manager/ks.yaml.nix
+++ b/manifests/cert-manager/cert-manager/ks.yaml.nix
@@ -1,1 +1,7 @@
-{k, ...}: k.fluxcd.kustomization ./. {}
+{k, ...}:
+k.fluxcd.kustomization ./. {
+  config.spec.dependsOn = map k.fluxcd.dep [
+    ../../kube-system/external-secrets/app
+    ./app
+  ];
+}

--- a/manifests/default/homepage/app/values.yaml.nix
+++ b/manifests/default/homepage/app/values.yaml.nix
@@ -1,9 +1,9 @@
 inputs @ {
-  self,
+  cluster,
   v,
   ...
 }: let
-  inherit (self.lib.cluster) domain;
+  inherit (cluster) domain;
 
   title = "Dornhaus";
 

--- a/manifests/default/inadyn/app/external-secret.yaml.nix
+++ b/manifests/default/inadyn/app/external-secret.yaml.nix
@@ -1,10 +1,11 @@
 {
+  cluster,
   k,
   v,
   self,
   ...
 }: let
-  inherit (self.lib) cluster yaml;
+  inherit (self.lib) yaml;
 in
   k.external-secret ./. {
     data."values.yaml" = yaml.format {

--- a/manifests/default/inadyn/ks.yaml.nix
+++ b/manifests/default/inadyn/ks.yaml.nix
@@ -1,1 +1,6 @@
-{k, ...}: k.fluxcd.kustomization ./. {}
+{k, ...}:
+k.fluxcd.kustomization ./. {
+  app.spec.dependsOn = map k.fluxcd.dep [
+    ../../kube-system/external-secrets/app
+  ];
+}

--- a/manifests/default/minecraft-bedrock/app/values.yaml.nix
+++ b/manifests/default/minecraft-bedrock/app/values.yaml.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  self,
+  cluster,
   ...
 }: let
   seed = toString 436606647;
@@ -43,5 +43,5 @@ in {
 
   # Use a pre-defined IP for the service.
   # This allows NAT-ing the service, making it available on the internet.
-  serviceAnnotations."lbipam.cilium.io/ips" = self.lib.cluster.network.external.minecraft;
+  serviceAnnotations."lbipam.cilium.io/ips" = cluster.network.external.minecraft;
 }

--- a/manifests/flux-system/external-secret.yaml.nix
+++ b/manifests/flux-system/external-secret.yaml.nix
@@ -4,6 +4,8 @@
   lib,
   ...
 }:
+# This requires the external secrets chart to be installed.
+# However a dependency is not declared to avoid introducing a cycle.
 k.external-secret ./. {
   name = "oci-auth";
   data.".dockerconfigjson" = let

--- a/manifests/flux-system/external-secret.yaml.nix
+++ b/manifests/flux-system/external-secret.yaml.nix
@@ -1,4 +1,5 @@
 {
+  cluster,
   k,
   lib,
   ...
@@ -6,17 +7,18 @@
 k.external-secret ./. {
   name = "oci-auth";
   data.".dockerconfigjson" = let
-    username = "flux";
+    username = cluster.owner;
     dckr.auth = "$DCKR_AUTH";
     ghcr.auth = "$GHCR_AUTH";
   in
     # Replace JSON-encoded string to avoid escaping the quotes below.
     builtins.replaceStrings [dckr.auth ghcr.auth] [
       ''{{ printf "${username}:%s" .dckr_token | b64enc }}''
+      # The GitHub registry ignores the username; only the token matters.
       ''{{ printf "${username}:%s" .ghcr_token | b64enc }}''
     ] (lib.strings.toJSON {
       auths = {
-        "registry-1.docker.io" = {
+        "docker.io" = {
           inherit username;
           inherit (dckr) auth;
           password = "{{ .dckr_token }}";

--- a/manifests/flux-system/flux-instance.yaml.nix
+++ b/manifests/flux-system/flux-instance.yaml.nix
@@ -1,5 +1,5 @@
 {
-  self,
+  cluster,
   k,
   v,
   ...
@@ -19,7 +19,7 @@ in {
     };
     sync = {
       inherit (import ./source.nix) kind;
-      url = with self.lib.cluster.github; "oci://${registry}/${owner}/${repository}";
+      url = with cluster.github; "oci://${registry}/${owner}/${repository}";
       ref = "latest";
       path = ".";
       pullSecret = "oci-auth";

--- a/manifests/flux-system/flux-instance.yaml.nix
+++ b/manifests/flux-system/flux-instance.yaml.nix
@@ -22,7 +22,7 @@ in {
       url = with self.lib.cluster.github; "oci://${registry}/${owner}/${repository}";
       ref = "latest";
       path = ".";
-      pullSecret = "ghcr-auth";
+      pullSecret = "oci-auth";
     };
     cluster = {
       type = "kubernetes";

--- a/manifests/ingress-nginx/ingress-nginx/app/values.yaml.nix
+++ b/manifests/ingress-nginx/ingress-nginx/app/values.yaml.nix
@@ -1,11 +1,11 @@
-inputs @ {self, ...}: let
+inputs @ {cluster, ...}: let
   namespace = "ingress-nginx";
   certificate = import ../config/certificate.yaml.nix inputs;
 in {
   controller = {
     replicaCount = 2;
     ingressClassResource.default = true;
-    service.annotations."lbipam.cilium.io/ips" = self.lib.cluster.network.external.ingress;
+    service.annotations."lbipam.cilium.io/ips" = cluster.network.external.ingress;
     extraArgs.default-ssl-certificate = "${namespace}/${certificate.spec.secretName}";
   };
 }

--- a/manifests/ingress-nginx/ingress-nginx/config/certificate.yaml.nix
+++ b/manifests/ingress-nginx/ingress-nginx/config/certificate.yaml.nix
@@ -1,11 +1,11 @@
 inputs @ {
-  self,
+  cluster,
   k,
   ...
 }:
 k.api "Certificate.cert-manager.io" (let
   inherit (issuer.metadata) name;
-  inherit (self.lib.cluster) domain;
+  inherit (cluster) domain;
 
   issuer = import ../../../cert-manager/cert-manager/config/cluster-issuer.yaml.nix inputs;
 in {

--- a/manifests/ingress-nginx/ingress-nginx/ks.yaml.nix
+++ b/manifests/ingress-nginx/ingress-nginx/ks.yaml.nix
@@ -1,13 +1,6 @@
-{
-  k,
-  lib,
-  ...
-}: let
-  inherit (builtins) elemAt;
-  all = k.fluxcd.kustomization ./. {};
-in [
-  (elemAt all 0) # app
-  (lib.attrsets.recursiveUpdate (elemAt all 1) {
-    spec.dependsOn = [{name = "cert-manager-config";}];
-  }) # config
-]
+{k, ...}:
+k.fluxcd.kustomization ./. {
+  config.spec.dependsOn = map k.fluxcd.dep [
+    ../../cert-manager/cert-manager/config
+  ];
+}

--- a/manifests/keycloak/keycloak/app/helm-release.yaml.nix
+++ b/manifests/keycloak/keycloak/app/helm-release.yaml.nix
@@ -1,0 +1,1 @@
+{k, ...}: k.fluxcd.helm-release ./. {}

--- a/manifests/keycloak/keycloak/app/kustomization.yaml.nix
+++ b/manifests/keycloak/keycloak/app/kustomization.yaml.nix
@@ -1,0 +1,1 @@
+{k, ...}: k.kustomization ./. {}

--- a/manifests/keycloak/keycloak/app/kustomizeconfig.yaml.nix
+++ b/manifests/keycloak/keycloak/app/kustomizeconfig.yaml.nix
@@ -1,0 +1,1 @@
+{k, ...}: k.kustomizeconfig

--- a/manifests/keycloak/keycloak/app/values.yaml.nix
+++ b/manifests/keycloak/keycloak/app/values.yaml.nix
@@ -1,0 +1,21 @@
+# https://artifacthub.io/packages/helm/bitnami/keycloak#parameters
+{k, ...}: {
+  # Use our own database.
+  postgresql.enabled = false;
+  # CloudNative PG managed cluster.
+  externalDatabase = {
+    existingSecret = "${k.fluxcd.ksname ../database}-app";
+    existingSecretHostKey = "host";
+    existingSecretPortKey = "port";
+    existingSecretUserKey = "user";
+    existingSecretDatabaseKey = "dbname";
+    existingSecretPasswordKey = "password";
+  };
+  extraEnvVars = [
+    {
+      name = "JAVA_OPTS";
+      # IPv6 should be fine, but just in case.
+      value = "-Djava.net.preferIPv4Stack=true";
+    }
+  ];
+}

--- a/manifests/keycloak/keycloak/database/cluster.yaml.nix
+++ b/manifests/keycloak/keycloak/database/cluster.yaml.nix
@@ -1,0 +1,11 @@
+{k, ...}:
+k.api "Cluster.postgresql.cnpg.io" {
+  metadata.name = k.fluxcd.ksname ./.;
+  spec = {
+    instances = 2;
+    storage.size = "2Gi";
+    bootstrap.initdb.database = k.appname ./.;
+
+    monitoring.enablePodMonitor = true;
+  };
+}

--- a/manifests/keycloak/keycloak/ks.yaml.nix
+++ b/manifests/keycloak/keycloak/ks.yaml.nix
@@ -1,0 +1,7 @@
+{k, ...}:
+k.fluxcd.kustomization ./. {
+  app.spec.dependsOn = map k.fluxcd.dep [./database];
+  database.spec.dependsOn = map k.fluxcd.dep [
+    ../../cnpg-system/cloudnative-pg/app
+  ];
+}

--- a/manifests/keycloak/kustomization.yaml.nix
+++ b/manifests/keycloak/kustomization.yaml.nix
@@ -1,0 +1,1 @@
+{k, ...}: k.kustomization ./. {}

--- a/manifests/keycloak/namespace.yaml.nix
+++ b/manifests/keycloak/namespace.yaml.nix
@@ -1,0 +1,4 @@
+{k, ...}:
+k.namespace ./. {
+  metadata.labels."goldilocks.fairwinds.com/enabled" = "true";
+}

--- a/manifests/kube-system/cilium/app/values.yaml.nix
+++ b/manifests/kube-system/cilium/app/values.yaml.nix
@@ -1,6 +1,4 @@
-{self, ...}: let
-  inherit (self.lib) cluster;
-in {
+{cluster, ...}: {
   # Uses KubePrism on Talos nodes.
   # Uses an IPtables rule on Alpine nodes without KubePrism.
   k8sServiceHost = "127.0.0.1";

--- a/manifests/kube-system/cilium/app/values.yaml.nix
+++ b/manifests/kube-system/cilium/app/values.yaml.nix
@@ -24,12 +24,12 @@
   routingMode = "native";
   autoDirectNodeRoutes = true;
   ipv4.enabled = true; # default
-  ipv4NativeRoutingCIDR = cluster.network.pod.cidr4;
+  ipv4NativeRoutingCIDR = cluster.network.node.cidr4;
 
-  # IPv6: temporarily disabled.
-  # Having troubles with direct routing as some nodes seem to pick up the global piblic address.
-  # ipv6.enabled = true; # default = false
-  # ipv6NativeRoutingCIDR = cluster.network.pod.cidr6;
+  ipv6.enabled = true; # default = false
+  # The Swisscom Router seems to advertise this address.
+  # We should use something self-configured but this will do for now.
+  ipv6NativeRoutingCIDR = cluster.network.node.cidr6;
 
   # Use L2 Announcements.
   l2announcements.enabled = true;

--- a/manifests/kube-system/cilium/config/l2-announcement-policy.yaml.nix
+++ b/manifests/kube-system/cilium/config/l2-announcement-policy.yaml.nix
@@ -1,10 +1,10 @@
 {
-  self,
+  cluster,
   k,
   ...
 }:
 k.api "CiliumL2AnnouncementPolicy.cilium.io" {
-  metadata.name = "${self.lib.cluster.name}-ips-l2-policy";
+  metadata.name = "${cluster.name}-ips-l2-policy";
   spec = {
     loadBalancerIPs = true;
     nodeSelector.matchLabels."kubernetes.io/arch" = "amd64";

--- a/manifests/kube-system/cilium/config/load-balancer-ip-pool.yaml.nix
+++ b/manifests/kube-system/cilium/config/load-balancer-ip-pool.yaml.nix
@@ -1,14 +1,12 @@
 {
-  self,
+  cluster,
   k,
   ...
 }:
-k.api "CiliumLoadBalancerIPPool.cilium.io" (let
-  inherit (self.lib) cluster;
-in {
+k.api "CiliumLoadBalancerIPPool.cilium.io" {
   metadata = {
     name = "${cluster.name}-ips";
     namespace = "kube-system";
   };
   spec.blocks = [{cidr = cluster.network.external.cidr4;}];
-})
+}

--- a/manifests/kube-system/cilium/ks.yaml.nix
+++ b/manifests/kube-system/cilium/ks.yaml.nix
@@ -1,4 +1,8 @@
 {k, ...}:
-k.fluxcd.kustomization ./. {
-  spec.prune = false; # should never be deleted
+k.fluxcd.kustomization ./. rec {
+  app.spec.prune = false;
+  config.spec = {
+    inherit (app.spec) prune;
+    dependsOn = map k.fluxcd.dep [./app];
+  };
 }

--- a/manifests/kube-system/external-secrets/ks.yaml.nix
+++ b/manifests/kube-system/external-secrets/ks.yaml.nix
@@ -1,1 +1,4 @@
-{k, ...}: k.fluxcd.kustomization ./. {}
+{k, ...}:
+k.fluxcd.kustomization ./. {
+  config.spec.dependsOn = map k.fluxcd.dep [./app];
+}

--- a/manifests/kube-system/kubelet-csr-approver/app/values.yaml.nix
+++ b/manifests/kube-system/kubelet-csr-approver/app/values.yaml.nix
@@ -1,6 +1,4 @@
-{self, ...}: let
-  inherit (self.lib) cluster;
-in {
+{cluster, ...}: {
   providerRegex = "^${cluster.name}-\\d{2}$";
   providerIpPrefixes = with cluster.network.node; "${cidr4Strict},${cidr6}";
   bypassDnsResolution = true;

--- a/manifests/observability/kube-prometheus-stack/app/values.yaml.nix
+++ b/manifests/observability/kube-prometheus-stack/app/values.yaml.nix
@@ -1,5 +1,5 @@
 inputs @ {
-  self,
+  cluster,
   k,
   ...
 }: let
@@ -7,7 +7,7 @@ inputs @ {
   certificate = import ../../../ingress-nginx/ingress-nginx/config/certificate.yaml.nix inputs;
 in {
   grafana = let
-    inherit (self.lib.cluster) domain;
+    inherit (cluster) domain;
     path = "/grafana";
   in {
     # Expose Grafana via an ingress path on the default hostname.

--- a/manifests/observability/kube-prometheus-stack/ks.yaml.nix
+++ b/manifests/observability/kube-prometheus-stack/ks.yaml.nix
@@ -1,1 +1,6 @@
-{k, ...}: k.fluxcd.kustomization ./. {}
+{k, ...}:
+k.fluxcd.kustomization ./. {
+  app.spec.dependsOn = map k.fluxcd.dep [
+    ../../kube-system/external-secrets/app
+  ];
+}

--- a/manifests/observability/vector/app/values.yaml.nix
+++ b/manifests/observability/vector/app/values.yaml.nix
@@ -1,9 +1,9 @@
-{self, ...}: {
+{cluster, ...}: {
   service = {
     # Expose the service externally.
     # Needed for Talos & Alpine logs forwarding.
     type = "LoadBalancer";
-    annotations."lbipam.cilium.io/ips" = self.lib.cluster.network.external.vector;
+    annotations."lbipam.cilium.io/ips" = cluster.network.external.vector;
   };
 
   autoscaling = {

--- a/manifests/openebs-system/zfs-localpv/ks.yaml.nix
+++ b/manifests/openebs-system/zfs-localpv/ks.yaml.nix
@@ -1,1 +1,4 @@
-{k, ...}: k.fluxcd.kustomization ./. {}
+{k, ...}:
+k.fluxcd.kustomization ./. {
+  config.spec.dependsOn = map k.fluxcd.dep [./app];
+}

--- a/modules/manifests/default.nix
+++ b/modules/manifests/default.nix
@@ -30,6 +30,7 @@
         inherit pkgs;
         name = dst;
         # Additional manifest params:
+        inherit cluster;
         k = self.lib.kubernetes;
         v = cluster.versions;
       };

--- a/talos/manifests/vector.yaml.nix
+++ b/talos/manifests/vector.yaml.nix
@@ -1,6 +1,6 @@
-{self, ...}: {
+{cluster, ...}: {
   kind = "KmsgLogConfig";
   apiVersion = "v1alpha1";
   name = "vector-logs";
-  url = "udp://${self.lib.cluster.network.external.vector}:6050/";
+  url = "udp://${cluster.network.external.vector}:6050/";
 }

--- a/talos/talconfig.yaml.nix
+++ b/talos/talconfig.yaml.nix
@@ -17,7 +17,7 @@
     networkInterfaces = [
       {
         deviceSelector.hardwareAddr = node.mac;
-        addresses = [node.net4];
+        addresses = with node; [net4 net6];
         routes = [
           {
             network = "0.0.0.0/0";
@@ -36,7 +36,7 @@
       (optional node.zfs "siderolabs/zfs")
     ];
 
-    extraManifests = map (src: yaml.write src {inherit pkgs;}) (flatten [
+    extraManifests = map (src: yaml.write src {inherit cluster pkgs;}) (flatten [
       (optional node.watchdog ./manifests/watchdog.yaml.nix)
       ./manifests/vector.yaml.nix
     ]);


### PR DESCRIPTION
Fix IPv6 networking on the way, since there was an issue with DNS name resolution with Keycloak (Java) while IPv6 networking was non-functional even though the pods had an IPv6 nameserver in /etc/resolve.conf.

IPv6 networking is back at full, again, but with the ULA provided by the stupid modem.