### PR TITLE
Be more liberal with Loki Canary upgrades

### DIFF
--- a/manifests/observability/loki/app/values.yaml.nix
+++ b/manifests/observability/loki/app/values.yaml.nix
@@ -36,5 +36,6 @@
     };
   };
 
-  lokiCanary.updateStrategy.rollingUpdate.maxUnavailable = 4;
+  # Be more liberal with canary upgrades, or else helm upgraed times out.
+  lokiCanary.updateStrategy.rollingUpdate.maxUnavailable = 4; # default: 1
 }

--- a/manifests/observability/loki/app/values.yaml.nix
+++ b/manifests/observability/loki/app/values.yaml.nix
@@ -35,4 +35,6 @@
       metricsInstance.enabled = true;
     };
   };
+
+  lokiCanary.updateStrategy.rollingUpdate.maxUnavailable = 4;
 }


### PR DESCRIPTION
Upgrading them one by one results in helm upgrade timeouts.