### PR TITLE
Pre-populate NFD OS ID label for Talos nodes

### DIFF
--- a/manifests/kube-system/spegel/app/values.yaml.nix
+++ b/manifests/kube-system/spegel/app/values.yaml.nix
@@ -1,5 +1,5 @@
 {
-  nodeSelector.distro = "talos";
+  nodeSelector."feature.node.kubernetes.io/system-os_release.ID" = "talos";
   spegel.containerdRegistryConfigPath = "/etc/cri/conf.d/hosts";
   revisionHistoryLimit = 4;
 }

--- a/talos/talconfig.yaml.nix
+++ b/talos/talconfig.yaml.nix
@@ -53,7 +53,9 @@
       }
     ];
 
-    nodeLabels = {distro = "talos";} // optionalAttrs node.zfs {pvpool = "zfs";};
+    nodeLabels =
+      {"feature.node.kubernetes.io/system-os_release.ID" = "talos";}
+      // optionalAttrs node.zfs {pvpool = "zfs";};
   };
 in {
   clusterName = cluster.name;


### PR DESCRIPTION
This avoids having a duplicate "distro" label.