### PR TITLE
SOPS JSON indent

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -16,5 +16,9 @@ creation_rules:
   key_groups: *keys
 
 stores:
+  json:
+    indent: 2
+  json_binary:
+    indent: 2
   yaml:
     indent: 2


### PR DESCRIPTION
This requires sops 3.9 though, which is not in nixpkgs yet.