### PR TITLE
feat: limit Cilium network interfaces to physical ones

### DIFF
--- a/manifests/kube-system/cilium/app/values.yaml.nix
+++ b/manifests/kube-system/cilium/app/values.yaml.nix
@@ -9,7 +9,7 @@
 
   # Tell Cilium to only manage the physical interface.
   # This will implicitly exclude others like the Tailscale interface.
-  devices = ["eth+"];
+  devices = ["eno+", "enp+", "eth+"];
 
   cgroup = {
     # Mount CGroup at a different location.

--- a/manifests/kube-system/cilium/app/values.yaml.nix
+++ b/manifests/kube-system/cilium/app/values.yaml.nix
@@ -1,9 +1,15 @@
+# https://docs.cilium.io/en/stable/helm-reference/
+# https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/values.yaml.tmpl
 {cluster, ...}: {
   # Enable KubeProxy replacement.
   k8sServiceHost = (builtins.head cluster.nodes.by.controlPlane).ipv6;
   k8sServicePort = 6443;
   kubeProxyReplacement = true;
   kubeProxyReplacementHealthzBindAddr = "[::]:10256";
+
+  # Tell Cilium to only manage the physical interface.
+  # This will implicitly exclude others like the Tailscale interface.
+  devices = ["eth+"];
 
   cgroup = {
     # Mount CGroup at a different location.

--- a/manifests/kube-system/cilium/app/values.yaml.nix
+++ b/manifests/kube-system/cilium/app/values.yaml.nix
@@ -9,7 +9,7 @@
 
   # Tell Cilium to only manage the physical interface.
   # This will implicitly exclude others like the Tailscale interface.
-  devices = ["eno+", "enp+", "eth+"];
+  devices = ["eno+" "enp+" "eth+"];
 
   cgroup = {
     # Mount CGroup at a different location.


### PR DESCRIPTION
This should avoid Cilium managing the Tailscale interface.

Fixes #447.