### PR TITLE
fix: disable dns forwarding

### DIFF
--- a/ansible/roles/tailscale/tasks/main.yaml
+++ b/ansible/roles/tailscale/tasks/main.yaml
@@ -35,6 +35,9 @@
     - --accept-routes=false
     - --accept-dns=false
     - --ssh
+    # Avoid configuring nftabels firewall rules.
+    # They clash with Cilium iptables rules, causing connectivity problems.
+    - --netfilter-mode=off
 
 - name: Configure IPv4/IPv6 forwarding
   ansible.posix.sysctl:

--- a/keycloak/realms/dh.json
+++ b/keycloak/realms/dh.json
@@ -1817,7 +1817,6 @@
     ]
   },
   "internationalizationEnabled": false,
-  "supportedLocales": [],
   "authenticationFlows": [
     {
       "id": "258883a8-d9f0-4f61-a2d2-4921f417f668",
@@ -2532,6 +2531,15 @@
       "config": {}
     },
     {
+      "alias": "idp_link",
+      "name": "Linking Identity Provider",
+      "providerId": "idp_link",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 110,
+      "config": {}
+    },
+    {
       "alias": "update_user_locale",
       "name": "Update User Locale",
       "providerId": "update_user_locale",
@@ -2565,7 +2573,7 @@
     "acr.loa.map": "{}",
     "darkMode": "true"
   },
-  "keycloakVersion": "26.1.4",
+  "keycloakVersion": "26.3.2",
   "userManagedAccessAllowed": false,
   "organizationsEnabled": false,
   "verifiableCredentialsEnabled": false,

--- a/manifests/ingress-nginx/ingress-nginx/app/values.yaml.nix
+++ b/manifests/ingress-nginx/ingress-nginx/app/values.yaml.nix
@@ -16,16 +16,18 @@ in {
     extraArgs.default-ssl-certificate = "${namespace}/${certificate.spec.secretName}";
 
     addHeaders = {
-      "content-security-policy" = concatStringsSep "; " [
-        "default-src 'self'"
-        # Homepage service icons are served from jsdelivr.
-        "img-src 'self' https://cdn.jsdelivr.net"
-        "script-src 'self' 'unsafe-inline'"
-        "style-src 'self' 'unsafe-inline'"
-        "form-action 'self'"
-        "frame-ancestors 'self'"
-        "object-src 'none'"
-      ];
+      # TODO: Specify fine-grained per-app policies.
+      #"content-security-policy" = concatStringsSep "; " [
+      #  "default-src 'self'"
+      #  # Homepage service icons are served from jsdelivr.
+      #  "img-src 'self' https://cdn.jsdelivr.net"
+      #  # Headlamp requires unsafe-eval, Alertmanager, Prometheus & Homepage require unsafe-inline.
+      #  "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+      #  "style-src 'self' 'unsafe-inline'"
+      #  "form-action 'self'"
+      #  "frame-ancestors 'self'"
+      #  "object-src 'none'"
+      #];
       "x-content-type-options" = "nosniff";
     };
     config.hide-headers = concatStringsSep "," [

--- a/manifests/kube-system/cilium/app/values.yaml.nix
+++ b/manifests/kube-system/cilium/app/values.yaml.nix
@@ -18,6 +18,14 @@
     hostRoot = "/sys/fs/cgroup";
   };
 
+  # Use eBPF-based masquerading.
+  # Requires disabling host DNS forwarding.
+  bpf.masquerade = true;
+
+  # Do not install iptables rules for connection tracking.
+  # https://docs.cilium.io/en/stable/operations/performance/tuning/#bypass-iptables-connection-tracking
+  installNoConntrackIptablesRules = true;
+
   # Enable use of per endpoint routes instead of routing via the cilium_host interface.
   endpointRoutes.enabled = true;
 

--- a/talos/talconfig.yaml.nix
+++ b/talos/talconfig.yaml.nix
@@ -44,9 +44,14 @@
     patches = map yaml.format [
       {
         machine = {
+          # Disable DNS forwarding, for two reasons:
+          # 1. Configuring it on Alpine nodes requires a non-trivial amount of effort.
+          # 2. It clashes with Cilium's eBPF-based masquerading: https://github.com/siderolabs/talos/issues/8836
+          features.hostDNS.forwardKubeDNSToHost = false;
           # Elasticsearch minimum requirements.
           # https://www.elastic.co/guide/en/elasticsearch/reference/8.17/bootstrap-checks-max-map-count.html
           sysctls."vm.max_map_count" = "262144";
+          # Redirect logs to Vector.
           logging.destinations = [
             {
               endpoint = "udp://${cluster.network.external.vector}:6051/";


### PR DESCRIPTION
- Avoids non-local redirect when CoreDNS doesn't land on a Talos node
- Allows enabling Cilium eBPF masquerade

Also:

- Update Keycloak realm export
- Disable netfilter