### PR TITLE
fix: cilium helm timeout should match the ks timeout

### DIFF
--- a/manifests/kube-system/cilium/app/helm-release.yaml.nix
+++ b/manifests/kube-system/cilium/app/helm-release.yaml.nix
@@ -2,5 +2,5 @@
 k.fluxcd.helm-release ./. {
   # Give Cilium more time to upgrade.
   # The "cilium" daemonset takes some time to fully roll out.
-  spec.timeout = "60m";
+  spec.timeout = "30m";
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the upgrade timeout for the CNI component from 60 minutes to 30 minutes.

* **Impact**
  * Faster feedback during upgrades with shorter rollout windows.
  * Quicker detection of stalled upgrades, enabling faster retries or rollbacks.
  * No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->