### PR TITLE
Revert "chore(deps): update ghcr.io/headlamp-k8s/headlamp docker tag to v0.35.0"

### DIFF
--- a/cluster/versions.nix
+++ b/cluster/versions.nix
@@ -15,7 +15,7 @@ in {
   flux.github-releases = ["fluxcd/flux2" "2.6.4"];
   goldilocks.docker = ["us-docker.pkg.dev/fairwinds-ops/oss/goldilocks" "4.14.4" vp];
   goldilocks.helm = ["https://charts.fairwinds.com/stable" "10.1.0"];
-  headlamp.docker = ["ghcr.io/headlamp-k8s/headlamp" "0.35.0" vp];
+  headlamp.docker = ["ghcr.io/headlamp-k8s/headlamp" "0.34.0" vp];
   headlamp.helm = ["https://kubernetes-sigs.github.io/headlamp" "0.34.0"];
   homepage.docker = ["ghcr.io/gethomepage/homepage" "1.4.6" vp];
   homepage.helm = ["https://jameswynn.github.io/helm-charts" "2.1.0"];


### PR DESCRIPTION
Reverts attilaolah/homelab#517.

Redirect loop in new version.