### PR TITLE
Replace ConnectBox 2 with 3, use DHCP range 192.168.0.0/16

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -9,7 +9,7 @@ creation_rules:
   key_groups: *keys
 - path_regex: talos/.*\.sops\.yaml
   key_groups: *keys
-- path_regex: manifests/kube-system/external-secrets/config/.*\.sops\.json
+- path_regex: bootstrap/external-secrets/.*\.sops\.json
   encrypted_regex: "^private_key(_id)?$"
   key_groups: *keys
 - path_regex: bootstrap/switches/.*\.cfg

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ router only advertises a global unicast prefix, no ULA (unique local address). T
 The router has IPv6 pinholing configured to access the load balancers from the outside. Cloudflare sits in front of the
 load balancers and provides IPv4 connectivity.
 
-For now, most nodes are configured to run in dual-stack mode, using `192.168.1.0/16` and the advertised IPv6 GUA
+For now, most nodes are configured to run in dual-stack mode, using `192.168.0.0/16` and the advertised IPv6 GUA
 subnet, as well as the automatic link-local `fd80::/10` subnet.
 
 ## 🧑‍💻️ Dev/Ops

--- a/README.md
+++ b/README.md
@@ -20,17 +20,14 @@ For bootstrapping with a custom domain, see: ["Custom Domain (one-time)"](bootst
 ## 🚧 IPv6 networking
 
 Currently, the cluster machines are connected to my ISP‑provided router via inexpensive 1 Gbps, L2‑only switches. This
-router advertises two IPv6 prefixes:
-
-- A `scope global`, `dynamic` prefix that belongs to the `2000::/3` range.
-- A Unique Local Address (ULA) prefix in `fd00::/8` (often shown as `scope global` in `ip addr`). On these modems this
-  appears as `fdaa:bbcc:ddee:0/64`.
+router only advertises a global unicast prefix, no ULA (unique local address). The prefix that belongs to the
+`2000::/3` range.
 
 The router has IPv6 pinholing configured to access the load balancers from the outside. Cloudflare sits in front of the
 load balancers and provides IPv4 connectivity.
 
-For now, most networks run in dual-stack mode, with all networks in the `10.0.0.0/8` and `fd10::/8` subnets, both
-routable locally.
+For now, most nodes are configured to run in dual-stack mode, using `192.168.1.0/16` and the advertised IPv6 GUA
+subnet, as well as the automatic link-local `fd80::/10` subnet.
 
 ## 🧑‍💻️ Dev/Ops
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The router has IPv6 pinholing configured to access the load balancers from the o
 load balancers and provides IPv4 connectivity.
 
 For now, most nodes are configured to run in dual-stack mode, using `192.168.0.0/16` and the advertised IPv6 GUA
-subnet, as well as the automatic link-local `fd80::/10` subnet.
+subnet, as well as the automatic link-local `fe80::/10` subnet.
 
 ## 🧑‍💻️ Dev/Ops
 

--- a/ansible/roles/network/files/etc/network/interfaces
+++ b/ansible/roles/network/files/etc/network/interfaces
@@ -2,6 +2,5 @@ auto lo
 iface lo inet loopback
 
 auto eth0
-
 iface eth0 inet dhcp
 iface eth0 inet6 auto

--- a/ansible/roles/network/files/etc/network/interfaces
+++ b/ansible/roles/network/files/etc/network/interfaces
@@ -2,5 +2,6 @@ auto lo
 iface lo inet loopback
 
 auto eth0
-iface eth0 inet dhcp
-iface eth0 inet6 auto
+iface eth0
+    use dhcp
+    use ipv6-ra

--- a/ansible/roles/network/tasks/main.yaml
+++ b/ansible/roles/network/tasks/main.yaml
@@ -10,13 +10,9 @@
     backup: true
 
 - name: Configure /etc/network/interfaces
-  ansible.builtin.template:
-    src: etc/network/interfaces.j2
+  ansible.builtin.copy:
+    src: etc/network/interfaces
     dest: /etc/network/interfaces
-    backup: true
-
-- name: Configure /etc/resolv.conf
-  ansible.builtin.template:
-    src: etc/resolv.conf.j2
-    dest: /etc/resolv.conf
-    backup: true
+    owner: root
+    group: root
+    mode: 0o644

--- a/ansible/roles/network/templates/etc/hosts.j2
+++ b/ansible/roles/network/templates/etc/hosts.j2
@@ -1,2 +1,2 @@
-127.0.0.1 localhost {{ inventory_hostname }}
-::1       localhost {{ inventory_hostname }}
+127.0.0.1 localhost {{ inventory_hostname }} {{ index }}.{{ cluster.name }}.{{ cluster.domain }}
+::1       localhost {{ inventory_hostname }} {{ index }}.{{ cluster.name }}.{{ cluster.domain }}

--- a/ansible/roles/network/templates/etc/network/interfaces.j2
+++ b/ansible/roles/network/templates/etc/network/interfaces.j2
@@ -3,12 +3,5 @@ iface lo inet loopback
 
 auto eth0
 
-iface eth0 inet6 static
-    address {{ net6 }}
-    gateway {{ network.uplink.gw6 }}
-    dns-nameservers{% for ip in network.uplink.dns6.three %} {{ ip }}{% endfor +%}
-
-iface eth0 inet static
-    address {{ net4 }}
-    gateway {{ network.uplink.gw4 }}
-    dns-nameservers{% for ip in network.uplink.dns4.three %} {{ ip }}{% endfor +%}
+iface eth0 inet dhcp
+iface eth0 inet6 auto

--- a/ansible/roles/network/templates/etc/resolv.conf.j2
+++ b/ansible/roles/network/templates/etc/resolv.conf.j2
@@ -1,3 +1,0 @@
-{% for ip in network.uplink.dns4.one + network.uplink.dns6.two %}
-nameserver {{ ip }}
-{% endfor +%}

--- a/ansible/roles/network/templates/etc/resolv.conf.j2
+++ b/ansible/roles/network/templates/etc/resolv.conf.j2
@@ -1,3 +1,3 @@
-{% for ip in network.uplink.dns6.two + network.uplink.dns4.one %}
+{% for ip in network.uplink.dns4.one + network.uplink.dns6.two %}
 nameserver {{ ip }}
 {% endfor +%}

--- a/cluster/network.nix
+++ b/cluster/network.nix
@@ -24,8 +24,8 @@ in {
     cidr4 = cidr net4 net4Len;
 
     net6 = "fd10:244::";
-    # The Controller Manager default node CIDR length is 64,
-    # and the distance between the nework length and the pod mask cannot be more than 16.
+    # The Controller Manager default node CIDR length is /64,
+    # and the distance between the nework length and the pod mask cannot be more than /16.
     net6Len = 64 - 16;
     cidr6 = cidr net6 net6Len;
   };

--- a/cluster/network.nix
+++ b/cluster/network.nix
@@ -1,14 +1,16 @@
 {self}: let
   inherit (self.lib) cidr;
+
+  prefix = "192.168.";
 in {
   node = rec {
-    net4 = "10.8.0.0";
-    net4Len = 16;
-    net4LenRoutable = 8;
+    net4 = "${prefix}8.0";
+    net4Len = 24;
+    net4LenRoutable = 16;
     cidr4 = cidr net4 net4Len;
 
     # L2 natively routable addresses.
-    routableCIDR4 = cidr "192.168.0.0" 16;
+    routableCIDR4 = cidr "${prefix}0.0" net4LenRoutable;
 
     # ULA set by the modem:
     net6 = "2001:1708:2601:d900::";
@@ -40,7 +42,7 @@ in {
   };
 
   external = rec {
-    net4 = "192.168.0.0";
+    net4 = "${prefix}0.0";
     net4Len = 16;
     cidr4 = cidr net4 net4Len;
 
@@ -51,17 +53,17 @@ in {
     };
 
     # External services:
-    ingress = "192.168.4.43";
-    minecraft = "192.168.19.132";
+    ingress = "${prefix}4.43";
+    minecraft = "${prefix}19.132";
 
     # Internal services:
-    vector = "192.168.5.5";
+    vector = "${prefix}5.5";
   };
 
   uplink = let
     pick = matrix: map builtins.head matrix;
   in {
-    gw4 = "192.168.0.1";
+    gw4 = "${prefix}0.1";
     gw6 = "fe80::200:5eff:fe00:103";
 
     dns4 = let

--- a/cluster/network.nix
+++ b/cluster/network.nix
@@ -1,16 +1,16 @@
 {self}: let
   inherit (self.lib) cidr;
 
-  prefix = "192.168.";
+  local = c: d: "192.168.${toString c}.${toString d}";
 in {
   node = rec {
-    net4 = "${prefix}8.0";
+    net4 = local 8 0;
     net4Len = 24;
     net4LenRoutable = 16;
     cidr4 = cidr net4 net4Len;
 
     # L2 natively routable addresses.
-    routableCIDR4 = cidr "${prefix}0.0" net4LenRoutable;
+    routableCIDR4 = cidr (local 0 0) net4LenRoutable;
 
     # ULA set by the modem:
     net6 = "2001:1708:2601:d900::";
@@ -42,7 +42,7 @@ in {
   };
 
   external = rec {
-    net4 = "${prefix}0.0";
+    net4 = local 0 0;
     net4Len = 16;
     cidr4 = cidr net4 net4Len;
 
@@ -53,17 +53,17 @@ in {
     };
 
     # External services:
-    ingress = "${prefix}4.43";
-    minecraft = "${prefix}19.132";
+    ingress = local 4 43;
+    minecraft = local 19 132;
 
     # Internal services:
-    vector = "${prefix}5.5";
+    vector = local 5 5;
   };
 
   uplink = let
     pick = matrix: map builtins.head matrix;
   in {
-    gw4 = "${prefix}1.1";
+    gw4 = local 1 1;
     gw6 = "fe80::200:5eff:fe00:103";
 
     dns4 = let

--- a/cluster/network.nix
+++ b/cluster/network.nix
@@ -4,13 +4,18 @@
   local = c: d: "192.168.${toString c}.${toString d}";
 in {
   node = rec {
-    net4 = local 8 0;
+    net4 = local 1 0;
     net4Len = 24;
-    net4LenRoutable = 16;
     cidr4 = cidr net4 net4Len;
 
     # L2 natively routable addresses.
+    # DHCP advertises a /24, however, the entire /16 should still be routable locally.
+    net4LenRoutable = 16;
     routableCIDR4 = cidr (local 0 0) net4LenRoutable;
+
+    # IPv4 node range: 192.168.1.100-254.
+    # Sunrise's ConnectBox 3 apparently won't let us configure DHCP with a /16 block.
+    offset = 100;
 
     # ULA set by the modem:
     net6 = "2001:1708:2601:d900::";

--- a/cluster/network.nix
+++ b/cluster/network.nix
@@ -8,10 +8,10 @@ in {
     cidr4 = cidr net4 net4Len;
 
     # L2 natively routable addresses.
-    routableCIDR4 = cidr "10.0.0.0" 8;
+    routableCIDR4 = cidr "192.168.0.0" 16;
 
     # ULA set by the modem:
-    net6 = "fdaa:bbcc:ddee::";
+    net6 = "2001:1708:2601:d900::";
     net6Len = 64;
     cidr6 = cidr net6 net6Len;
   };
@@ -40,7 +40,7 @@ in {
   };
 
   external = rec {
-    net4 = "10.10.0.0";
+    net4 = "192.168.0.0";
     net4Len = 16;
     cidr4 = cidr net4 net4Len;
 
@@ -51,18 +51,18 @@ in {
     };
 
     # External services:
-    ingress = "10.10.4.43";
-    minecraft = "10.10.19.132";
+    ingress = "192.168.4.43";
+    minecraft = "192.168.19.132";
 
     # Internal services:
-    vector = "10.10.0.5";
+    vector = "192.168.5.5";
   };
 
   uplink = let
     pick = matrix: map builtins.head matrix;
   in {
-    gw4 = "10.0.0.1";
-    gw6 = "fe80::3a35:fbff:fe0d:c7bf";
+    gw4 = "192.168.0.1";
+    gw6 = "fe80::200:5eff:fe00:103";
 
     dns4 = let
       cloudflare = ["1.1.1.1" "1.0.0.1"];

--- a/cluster/network.nix
+++ b/cluster/network.nix
@@ -1,6 +1,8 @@
 {self}: let
   inherit (self.lib) cidr;
 
+  # IPv4 subnet enforced by the router.
+  # Using any other subnet would work for local comms but not for internet connectivity.
   local = c: d: "192.168.${toString c}.${toString d}";
 in {
   node = rec {
@@ -17,7 +19,7 @@ in {
     # Sunrise's ConnectBox 3 apparently won't let us configure DHCP with a /16 block.
     offset = 100;
 
-    # ULA set by the modem:
+    # GUA prefix set by the modem:
     net6 = "2001:1708:2601:d900::";
     net6Len = 64;
     cidr6 = cidr net6 net6Len;

--- a/cluster/network.nix
+++ b/cluster/network.nix
@@ -63,7 +63,7 @@ in {
   uplink = let
     pick = matrix: map builtins.head matrix;
   in {
-    gw4 = "${prefix}0.1";
+    gw4 = "${prefix}1.1";
     gw6 = "fe80::200:5eff:fe00:103";
 
     dns4 = let

--- a/cluster/network.nix
+++ b/cluster/network.nix
@@ -32,7 +32,7 @@ in {
 
     net6 = "fd10:244::";
     # The Controller Manager default node CIDR length is /64,
-    # and the distance between the nework length and the pod mask cannot be more than /16.
+    # and the distance between the network length and the pod mask cannot be more than /16.
     net6Len = 64 - 16;
     cidr6 = cidr net6 net6Len;
   };

--- a/lib/nodes.nix
+++ b/lib/nodes.nix
@@ -16,7 +16,7 @@ map (src: let
   index = removeSuffix ".nix" (baseNameOf src);
 
   pre4 = substring 0 (stringLength node.net4 - 2) node.net4;
-  ipv4 = "${pre4}.${toString (toIntBase10 index)}";
+  ipv4 = "${pre4}.${toString ((toIntBase10 index) + node.offset)}";
   ipv6 = eui64 node.net6 data.mac;
 
   extras = {

--- a/lib/nodes.nix
+++ b/lib/nodes.nix
@@ -3,6 +3,7 @@
   self,
 }: dir:
 map (src: let
+  inherit (builtins) stringLength substring;
   inherit (lib.strings) removeSuffix toIntBase10;
   inherit (self.lib) cluster eui64;
   inherit (cluster.network) node;
@@ -14,7 +15,7 @@ map (src: let
   data = defaults // (import src);
   index = removeSuffix ".nix" (baseNameOf src);
 
-  pre4 = builtins.substring 0 (builtins.stringLength node.net4 - 2) node.net4;
+  pre4 = substring 0 (stringLength node.net4 - 2) node.net4;
   ipv4 = "${pre4}.${toString (toIntBase10 index)}";
   ipv6 = eui64 node.net6 data.mac;
 

--- a/lib/nodes.nix
+++ b/lib/nodes.nix
@@ -20,7 +20,7 @@ map (src: let
   ipv6 = eui64 node.net6 data.mac;
 
   extras = {
-    inherit ipv4 ipv6;
+    inherit index ipv4 ipv6;
 
     hostname = "${cluster.name}-${index}";
     net4 = "${ipv4}/${toString node.net4LenRoutable}";

--- a/manifests/infrastructure/inadyn/app/external-secret.yaml.nix
+++ b/manifests/infrastructure/inadyn/app/external-secret.yaml.nix
@@ -8,17 +8,19 @@
 in
   k.external-secret ./. {
     data."values.yaml" = yaml.format {
-      inadynConfig = ''
+      inadynConfig = with cluster; ''
         period = 480
 
-        provider cloudflare.com { # main
-            hostname = ${cluster.domain}
-            username = ${cluster.domain}
+        # A ${domain}
+        provider cloudflare.com {
+            hostname = ${domain}
+            username = ${domain}
             password = {{ .cloudflare_api_token }}
             ttl = 1 # automatic
         }
 
-        provider duckdns.org { # backup
+        # CNAME duckdns.${domain}
+        provider duckdns.org {
             hostname = dornhaus.duckdns.org
             username = {{ .duckdns_token }}
         }

--- a/manifests/kube-system/cilium/app/values.yaml.nix
+++ b/manifests/kube-system/cilium/app/values.yaml.nix
@@ -2,7 +2,7 @@
 # https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/values.yaml.tmpl
 {cluster, ...}: {
   # Enable KubeProxy replacement.
-  k8sServiceHost = (builtins.head cluster.nodes.by.controlPlane).ipv6;
+  k8sServiceHost = (builtins.head cluster.nodes.by.controlPlane).ipv4;
   k8sServicePort = 6443;
   kubeProxyReplacement = true;
   kubeProxyReplacementHealthzBindAddr = "[::]:10256";

--- a/modules/task/taskfiles/flux.yaml.nix
+++ b/modules/task/taskfiles/flux.yaml.nix
@@ -219,7 +219,7 @@ in {
         text = ''
           echo "Decoding GCP service account key…"
           service_account_key="$(
-            sops --decrypt "$DEVENV_ROOT/manifests/${namespace}/${name}/config/${secret.name}.sops.json" |
+            sops --decrypt "$DEVENV_ROOT/bootstrap/${name}/${secret.name}.sops.json" |
               jq --compact-output .
           )"
           echo "Storing GCP service account in Kubernetes secret ${secret.namespace}/${secret.name}"

--- a/talos/talconfig.yaml.nix
+++ b/talos/talconfig.yaml.nix
@@ -109,7 +109,7 @@ in {
           extraConfig.serverTLSBootstrap = true;
           nodeIP.validSubnets = with cluster.network.node; [cidr4 cidr6];
         };
-        network.nameservers = with cluster.network.uplink; dns4.two ++ dns6.one;
+        network.nameservers = with cluster.network.uplink; dns4.one ++ dns6.two;
       };
     }
   ];

--- a/talos/talconfig.yaml.nix
+++ b/talos/talconfig.yaml.nix
@@ -14,20 +14,6 @@
 
     ipAddress = node.ipv4;
     installDiskSelector.type = "ssd";
-    networkInterfaces = [
-      {
-        deviceSelector.hardwareAddr = node.mac;
-        addresses = with node; [net4 net6];
-        routes = [
-          {
-            network = "0.0.0.0/0";
-            gateway = cluster.network.uplink.gw4;
-          }
-          # IPv6 default route is auto-configured.
-        ];
-        dhcp = false;
-      }
-    ];
 
     kernelModules = optional node.zfs {name = "zfs";};
 


### PR DESCRIPTION
Change uplinx from Sunrise ConnectBox 2 to ConnectBox 3.

The new router is better but less configurable, so the local network is fourced to a /24 block under 192.168../16. Since DHCP reservations actually work now, we can use that, but since the same IP range now has to contain other network equipment, and we are still limited to a /24 range, I've put in an offset so the locker nodes all start at 192.168.1.100..., instead of fragmenting the network even further.

Another improvement is that the ConnectBox supports DuckDNS out of the box. The Inadyn deployment will still keep petting the duck, but the ConectBox will now do so as well, which is an extra layer of redundancy, meaning I get a CNAME that points home even in case the Inadyn deployment fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched primary interfaces to DHCP/automatic IPv6 and removed per-node static interface declarations.
  * Simplified network file handling by using static copies instead of rendered templates; removed template-generated nameserver entries.
  * Revised IPv4/IPv6 addressing and routable ranges, added a node-level offset for host addressing, and updated external/uplink addresses and gateways.
  * Control-plane service host now uses IPv4; DNS selection order adjusted.

* **Documentation**
  * Updated networking docs to describe the new IPv4 scheme and global IPv6 prefix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->