### PR TITLE
Use on-demand activation for low-traffic services

### DIFF
--- a/docs/pki.md
+++ b/docs/pki.md
@@ -180,5 +180,3 @@ test "$(clan vars get "$machine" acme-db/key.sealed | wc -c)" -gt 0
 If this check fails, re-run `acme-db-seal "$machine"` and check again.
 
 4. Deploy the machine. This installs socket activation (`step-ca-proxy.socket`) and on-demand ACME services.
-
-Without a sealed key, or if TPM unsealing fails, `step-ca-acme.service` does not start.

--- a/docs/pki.md
+++ b/docs/pki.md
@@ -179,6 +179,6 @@ test "$(clan vars get "$machine" acme-db/key.sealed | wc -c)" -gt 0
 
 If this check fails, re-run `acme-db-seal "$machine"` and check again.
 
-4. Deploy the machine. This installs and starts both `step-ca-db-mount.service` and `step-ca-acme.service`.
+4. Deploy the machine. This installs socket activation (`step-ca-proxy.socket`) and on-demand ACME services.
 
 Without a sealed key, or if TPM unsealing fails, `step-ca-acme.service` does not start.

--- a/modules/tags/acme.nix
+++ b/modules/tags/acme.nix
@@ -194,7 +194,7 @@ in {
         what = dbCryptPath;
         where = dbPath;
         type = "fuse.gocryptfs";
-        options = "extpass=${lib.getExe dbExtpass}";
+        options = "extpass=${lib.getExe dbExtpass},nosyslog";
         startLimitBurst = 3;
         unitConfig = {
           Requires = ["step-ca-db-prepare.service"];

--- a/modules/tags/acme.nix
+++ b/modules/tags/acme.nix
@@ -11,9 +11,30 @@
   machineData = import (inputs.self + /inventory/data.nix);
   common = import ./tpm12/common.nix {inherit config lib pkgs;};
   dbPath = "${acme.stepPath}/db";
-  dbCryptPath = "${acme.stepPath}/db.crypt";
+  dbCryptPath = "${dbPath}.crypt";
   dbKeySealed = config.clan.core.vars.generators.acme-db.files."key.sealed".path;
   backendAddress = "127.0.0.1:${toString (acme.port + 1)}";
+  dbExtpass = pkgs.writeShellApplication {
+    name = "step-ca-db-extpass";
+    runtimeInputs = with pkgs; [coreutils tpm-tools];
+    text = ''
+      set -euo pipefail
+
+      if [[ ! -s ${dbKeySealed} ]]; then
+        echo "sealed DB key is missing (${dbKeySealed})" >&2
+        exit 1
+      fi
+
+      key="$(mktemp /run/step-ca-db-key.XXXXXX)"
+      cleanup() {
+        rm -f "$key"
+      }
+      trap cleanup EXIT
+
+      tpm_unsealdata -z -i ${dbKeySealed} -o "$key"
+      cat "$key"
+    '';
+  };
 
   acmeFqdns = map (name: "${name}.${config.networking.domain}") (builtins.attrNames config.homelab.acme.hosts);
   acmeClients = lib.unique ((machineData.tags.acme_client or []) ++ (machineData.tags.acme_client_bootstrap or []));
@@ -34,7 +55,7 @@
     logger.format = "text";
     db = {
       type = "badgerv2";
-      dataSource = "${acme.stepPath}/db";
+      dataSource = "${dbPath}";
     };
     authority.provisioners = [
       {
@@ -69,61 +90,34 @@ in {
     ];
 
     services = {
-      step-ca-db-mount = let
+      step-ca-db-prepare = let
         after = [
           "tcsd.service"
           "systemd-tmpfiles-setup.service"
         ];
       in {
         inherit after;
-        description = "Mount encrypted Step CA Badger DB";
+        description = "Prepare encrypted Step CA Badger DB";
         wants = after;
-        before = ["step-ca-acme.service"];
-        path = with pkgs; [coreutils findutils gocryptfs tpm-tools util-linux];
+        before = ["var-lib-step\\x2dca-db.mount"];
+        path = with pkgs; [gocryptfs];
         unitConfig.StopWhenUnneeded = true;
 
         serviceConfig = {
           Type = "oneshot";
-          RemainAfterExit = true;
           UMask = "0077";
         };
 
         script = ''
           set -euo pipefail
 
-          if mountpoint -q ${dbPath}; then
-            mounted_source="$(findmnt -n -T ${dbPath} -o SOURCE || true)"
-            if [[ "$mounted_source" == "${dbCryptPath}" ]]; then
-              exit 0
-            fi
-            echo "unexpected mount at ${dbPath}: $mounted_source" >&2
-            exit 1
-          fi
-
           if [[ ! -s ${dbKeySealed} ]]; then
             echo "sealed DB key is missing (${dbKeySealed})" >&2
             exit 1
           fi
 
-          key="$(mktemp /run/step-ca-db-key.XXXXXX)"
-          cleanup() {
-            rm -f "$key"
-          }
-          trap cleanup EXIT
-
-          tpm_unsealdata -z -i ${dbKeySealed} -o "$key"
-          chmod 0600 "$key"
-
           if [[ ! -f ${dbCryptPath}/gocryptfs.conf ]]; then
-            gocryptfs -q -init -passfile "$key" ${dbCryptPath}
-          fi
-
-          gocryptfs -q -passfile "$key" ${dbCryptPath} ${dbPath}
-        '';
-
-        postStop = ''
-          if mountpoint -q ${dbPath}; then
-            umount ${dbPath}
+            ${lib.getExe' pkgs.gocryptfs "gocryptfs"} -q -init -extpass ${lib.getExe dbExtpass} ${dbCryptPath}
           fi
         '';
       };
@@ -132,13 +126,11 @@ in {
         after = [
           "tcsd.service"
           "systemd-tmpfiles-setup.service"
-          "step-ca-db-mount.service"
         ];
       in {
         inherit after;
         description = "Step CA ACME service";
         wants = after;
-        requires = ["step-ca-db-mount.service"];
         path = with pkgs; [step-ca step-cli step-kms-plugin];
         unitConfig.StopWhenUnneeded = true;
 
@@ -152,6 +144,7 @@ in {
           Type = "simple";
           StateDirectory = "step-ca";
           StateDirectoryMode = "0700";
+          RequiresMountsFor = [dbPath];
           ExecStart = "${lib.getExe pkgs.step-ca} ${caConfig}";
           Restart = "on-failure";
           RestartSec = "10s";
@@ -172,20 +165,51 @@ in {
 
         serviceConfig = {
           Type = "notify";
-          ExecStartPre = "${pkgs.bash}/bin/bash -euo pipefail -c ${lib.escapeShellArg ''
-            deadline=$((SECONDS + 30))
-            while ! nc -z 127.0.0.1 ${toString (acme.port + 1)}; do
-              if (( SECONDS >= deadline )); then
-                echo "step-ca backend did not become ready on ${backendAddress}" >&2
-                exit 1
-              fi
-              sleep 0.2
-            done
-          ''}";
+          ExecStartPre = lib.getExe (pkgs.writeShellApplication {
+            name = "wait-step-ca-backend";
+            runtimeInputs = with pkgs; [coreutils netcat-openbsd];
+            text = ''
+              set -euo pipefail
+
+              deadline=$((SECONDS + 30))
+              while ! nc -z 127.0.0.1 ${toString (acme.port + 1)}; do
+                if (( SECONDS >= deadline )); then
+                  echo "step-ca backend did not become ready on ${backendAddress}" >&2
+                  exit 1
+                fi
+                sleep 0.2
+              done
+            '';
+          });
           ExecStart = "${pkgs.systemd}/lib/systemd/systemd-socket-proxyd --exit-idle-time=2min ${backendAddress}";
         };
       };
     };
+
+    mounts = [
+      {
+        description = "Encrypted Step CA Badger DB";
+        what = dbCryptPath;
+        where = dbPath;
+        type = "fuse.gocryptfs";
+        options = "extpass=${lib.getExe dbExtpass}";
+        startLimitBurst = 3;
+        unitConfig = {
+          Requires = ["step-ca-db-prepare.service"];
+          After = ["step-ca-db-prepare.service"];
+          StopWhenUnneeded = true;
+        };
+      }
+    ];
+
+    automounts = [
+      {
+        description = "Automount for encrypted Step CA Badger DB";
+        where = dbPath;
+        wantedBy = ["multi-user.target"];
+        automountConfig.TimeoutIdleSec = "10min";
+      }
+    ];
 
     sockets.step-ca-proxy = {
       description = "Socket activation for Step CA ACME endpoint";
@@ -194,6 +218,8 @@ in {
       socketConfig.Accept = false;
     };
   };
+
+  system.fsPackages = [pkgs.gocryptfs];
 
   environment.systemPackages = [inputs.acme-eab.packages.${system}.acme-eab];
 }

--- a/modules/tags/acme.nix
+++ b/modules/tags/acme.nix
@@ -132,7 +132,10 @@ in {
         description = "Step CA ACME service";
         wants = after;
         path = with pkgs; [step-ca step-cli step-kms-plugin];
-        unitConfig.StopWhenUnneeded = true;
+        unitConfig = {
+          StopWhenUnneeded = true;
+          RequiresMountsFor = [dbPath];
+        };
 
         environment = {
           HOME = common.tpm;
@@ -144,7 +147,6 @@ in {
           Type = "simple";
           StateDirectory = "step-ca";
           StateDirectoryMode = "0700";
-          RequiresMountsFor = [dbPath];
           ExecStart = "${lib.getExe pkgs.step-ca} ${caConfig}";
           Restart = "on-failure";
           RestartSec = "10s";
@@ -197,7 +199,6 @@ in {
         unitConfig = {
           Requires = ["step-ca-db-prepare.service"];
           After = ["step-ca-db-prepare.service"];
-          StopWhenUnneeded = true;
         };
       }
     ];

--- a/modules/tags/acme.nix
+++ b/modules/tags/acme.nix
@@ -13,6 +13,7 @@
   dbPath = "${acme.stepPath}/db";
   dbCryptPath = "${acme.stepPath}/db.crypt";
   dbKeySealed = config.clan.core.vars.generators.acme-db.files."key.sealed".path;
+  backendAddress = "127.0.0.1:${toString (acme.port + 1)}";
 
   acmeFqdns = map (name: "${name}.${config.networking.domain}") (builtins.attrNames config.homelab.acme.hosts);
   acmeClients = lib.unique ((machineData.tags.acme_client or []) ++ (machineData.tags.acme_client_bootstrap or []));
@@ -28,7 +29,7 @@
     root = config.clan.core.vars.generators.tls-ca.files."ca.crt".path;
     crt = "${common.tpm}/${common.crt}";
     key = common.pkcs11.key;
-    address = ":${toString acme.port}";
+    address = backendAddress;
     dnsNames = acmeFqdns;
     logger.format = "text";
     db = {
@@ -77,9 +78,9 @@ in {
         inherit after;
         description = "Mount encrypted Step CA Badger DB";
         wants = after;
-        wantedBy = ["multi-user.target"];
         before = ["step-ca-acme.service"];
         path = with pkgs; [coreutils findutils gocryptfs tpm-tools util-linux];
+        unitConfig.StopWhenUnneeded = true;
 
         serviceConfig = {
           Type = "oneshot";
@@ -138,8 +139,8 @@ in {
         description = "Step CA ACME service";
         wants = after;
         requires = ["step-ca-db-mount.service"];
-        wantedBy = ["multi-user.target"];
         path = with pkgs; [step-ca step-cli step-kms-plugin];
+        unitConfig.StopWhenUnneeded = true;
 
         environment = {
           HOME = common.tpm;
@@ -156,6 +157,30 @@ in {
           RestartSec = "10s";
         };
       };
+
+      step-ca-proxy = let
+        after = [
+          "step-ca-acme.service"
+          "step-ca-proxy.socket"
+        ];
+      in {
+        inherit after;
+        description = "Socket-activated proxy to Step CA ACME backend";
+        wants = after;
+        requires = after;
+
+        serviceConfig = {
+          Type = "notify";
+          ExecStart = "${pkgs.systemd}/lib/systemd/systemd-socket-proxyd --exit-idle-time=2min ${backendAddress}";
+        };
+      };
+    };
+
+    sockets.step-ca-proxy = {
+      description = "Socket activation for Step CA ACME endpoint";
+      wantedBy = ["sockets.target"];
+      listenStreams = [(toString acme.port)];
+      socketConfig.Accept = false;
     };
   };
 

--- a/modules/tags/acme.nix
+++ b/modules/tags/acme.nix
@@ -25,14 +25,7 @@
         exit 1
       fi
 
-      key="$(mktemp /run/step-ca-db-key.XXXXXX)"
-      cleanup() {
-        rm -f "$key"
-      }
-      trap cleanup EXIT
-
-      tpm_unsealdata -z -i ${dbKeySealed} -o "$key"
-      cat "$key"
+      exec tpm_unsealdata -z -i ${dbKeySealed}
     '';
   };
 

--- a/modules/tags/acme.nix
+++ b/modules/tags/acme.nix
@@ -92,8 +92,6 @@ in {
         inherit after;
         description = "Prepare encrypted Step CA Badger DB";
         wants = after;
-        before = ["var-lib-step\\x2dca-db.mount"];
-        path = with pkgs; [gocryptfs];
         unitConfig.StopWhenUnneeded = true;
 
         serviceConfig = {
@@ -156,7 +154,6 @@ in {
         description = "Socket-activated proxy to Step CA ACME backend";
         wants = after;
         requires = after;
-        path = with pkgs; [coreutils netcat-openbsd];
 
         serviceConfig = {
           Type = "notify";

--- a/modules/tags/acme.nix
+++ b/modules/tags/acme.nix
@@ -168,9 +168,20 @@ in {
         description = "Socket-activated proxy to Step CA ACME backend";
         wants = after;
         requires = after;
+        path = with pkgs; [coreutils netcat-openbsd];
 
         serviceConfig = {
           Type = "notify";
+          ExecStartPre = "${pkgs.bash}/bin/bash -euo pipefail -c ${lib.escapeShellArg ''
+            deadline=$((SECONDS + 30))
+            while ! nc -z 127.0.0.1 ${toString (acme.port + 1)}; do
+              if (( SECONDS >= deadline )); then
+                echo "step-ca backend did not become ready on ${backendAddress}" >&2
+                exit 1
+              fi
+              sleep 0.2
+            done
+          ''}";
           ExecStart = "${pkgs.systemd}/lib/systemd/systemd-socket-proxyd --exit-idle-time=2min ${backendAddress}";
         };
       };

--- a/modules/tags/all.nix
+++ b/modules/tags/all.nix
@@ -122,7 +122,10 @@ in {
     system.disableInstallerTools = true;
     environment.defaultPackages = lib.mkForce [];
 
-    # D-Bus defaults to X11 autolaunch support.
-    services.dbus.dbusPackage = pkgs.dbus.override {x11Support = false;};
+    services = {
+      # D-Bus defaults to X11 autolaunch support.
+      dbus.dbusPackage = pkgs.dbus.override {x11Support = false;};
+      openssh.startWhenNeeded = true;
+    };
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified ACME deployment steps: deployment now mentions installation of the proxy socket and socket-activated on-demand ACME services.

* **New Features**
  * ACME now starts on-demand via socket activation.
  * OpenSSH can be started on-demand.
  * Encrypted ACME database mounting is initialized and validated automatically at boot.

* **Refactor**
  * ACME backend reworked to use a local proxy and localhost binding for better isolation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/attilaolah/homelab/pull/688)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->